### PR TITLE
出力を常にroad_nameとorderでソート

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -336,7 +336,8 @@ class RoadMaker:
             columns=["road_name", "order", "name", "kp", "is_IC", "is_SIC", "is_JCT", "is_SAPA", "geometry"])
 
         print(gdf_point_cur)
-        gdf_point = gpd.GeoDataFrame(pd.concat([gdf_point, gdf_point_cur]))
+        gdf_point = gdf_point.append(gdf_point_cur)
+        gdf_point.sort_values(["road_name", "order"], inplace=True)
         gdf_point.to_file(RoadMaker.RESULT_HIGHWAY_POINT, driver='GeoJSON')
 
         # LINESTRING
@@ -352,7 +353,8 @@ class RoadMaker:
             columns=["road_name", "order", "source", "target", "geometry"])
 
         print(gdf_path_cur)
-        gdf_path = gpd.GeoDataFrame(pd.concat([gdf_path, gdf_path_cur]))
+        gdf_path = gdf_path.append(gdf_path_cur)
+        gdf_path.sort_values(["road_name", "order"], inplace=True)
         gdf_path.to_file(RoadMaker.RESULT_HIGHWAY_PATH, driver='GeoJSON')
 
     def _del_path(self, del_indices: set[int]) -> None:


### PR DESCRIPTION
データの更新/修正時に、ソート済みの方がgitで差分を取りやすくなる。
[Initial commit](https://github.com/yH3PO4/HighwayOrderedDS/commit/eadc0421ec5af3a508d664aa8502257fd8feea93) ではソートしてあったのでそれに合わせた。